### PR TITLE
Add `Sessions` page

### DIFF
--- a/src/app/App.css
+++ b/src/app/App.css
@@ -68,8 +68,22 @@ th {
   width: 8em;
 }
 
+th.-left {
+  text-align: left;
+  padding-left: 1em;
+}
+
+th.-wide {
+  width: 24em;
+}
+
 td {
   text-align: right;
+}
+
+td.-left {
+  text-align: left;
+  padding-left: 1em;
 }
 
 td.-fade {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,6 +1,7 @@
 import Header from '../components/Header';
 import Paces from '../features/paces/Paces';
 import Zones from '../features/zones/Zones';
+import Sessions from '../features/sessions/Sessions';
 import Strength from '../features/strength/Strength';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import './App.css'
@@ -11,6 +12,7 @@ function App() {
     <Routes>
       <Route path="/" element={<Paces />} />
       <Route path="/zones" element={<Zones />} />
+      <Route path="/sessions" element={<Sessions />} />
       <Route path="/strength" element={<Strength />} />
     </Routes>
   </BrowserRouter>;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,6 +8,7 @@ function Header() {
       <ul>
         <li><Link to="/">Paces</Link></li>
         <li><Link to="/zones">Zones</Link></li>
+        <li><Link to="/sessions">Sessions</Link></li>
         <li><Link to="/strength">Strength</Link></li>
       </ul>
     </nav>

--- a/src/features/sessions/Sessions.tsx
+++ b/src/features/sessions/Sessions.tsx
@@ -1,0 +1,5 @@
+function Sessions() {
+  return <></>;
+}
+
+export default Sessions;

--- a/src/features/zones/HeartZones.tsx
+++ b/src/features/zones/HeartZones.tsx
@@ -45,14 +45,15 @@ function calculateZones(resting: number, maximum: number, lactateThreshold: numb
   const lthr = calculateLactateThreshold(resting, lactateThreshold);
 
   return [
-    '(Recovery) 1',
-    '(Aerobic) 2',
-    '(Tempo) 3',
-    '(Threshold) 4',
-    '(Maximum) 5',
-  ].map((zone, i) => {
+    ['(Recovery) 1', 'Muscle recovery'],
+    ['(Aerobic) 2', 'Muscle recovery and improves aerobic capacity'],
+    ['(Tempo) 3', 'Improves aerobic capacity'],
+    ['(Threshold) 4', 'Improves lactate threshold'],
+    ['(Maximum) 5', 'Improves V̇O₂ max and speed'],
+  ].map(([zone, benefit], i) => {
     return {
       zone,
+      benefit,
       mhr: { lower: mhr[i], upper: mhr[i+1] },
       hrr: { lower: hrr[i], upper: hrr[i+1] },
       lthr: { lower: lthr[i], upper: lthr[i+1] },
@@ -76,8 +77,8 @@ function HeartZones() {
 
   return <>
     <p>
-      This table shows the heart rate zones based on your resting heart rate,
-      maximum heart rate, and lactate threshold.
+      This table shows the heart rate zones together with their benefits based
+      on your resting heart rate, maximum heart rate, and lactate threshold.
     </p>
     <form onSubmit={e => updateZoneValues(e)} className='-multiple'>
       <label>
@@ -101,16 +102,18 @@ function HeartZones() {
           <th>MHR%</th>
           <th>HRR%</th>
           <th>LTHR%</th>
+          <th className="-left -wide">Benefits</th>
         </tr>
       </thead>
       <tbody>
         {
-          zones.map(({zone, mhr, hrr, lthr}) => {
+          zones.map(({zone, benefit, mhr, hrr, lthr}) => {
             return <tr key={zone}>
               <td>{zone}</td>
               <td>{mhr.lower.toFixed(0)} - {mhr.upper.toFixed(0)}</td>
               <td>{hrr.lower.toFixed(0)} - {hrr.upper.toFixed(0)}</td>
               <td>{lthr.lower.toFixed(0)} - {lthr.upper.toFixed(0)}</td>
+              <td className="-left">{benefit}</td>
             </tr>;
           })
         }


### PR DESCRIPTION
Add a new `Sessions` component which renders a new page for showing how different types of training sessions correspond to different heart rate zones and expected improvements.

Unfortunately there seems to be some disagreement online about heart rate zones for _"Easy Runs"_. For example, Garmin says easy running is done in Zone 3 but most other sites considers Zone 2 easy running. I've taken the middle ground and said the lower half of Zone 3 is acceptable for easy running, which seems to match up with the expected benefits.

# Screenshot

![image](https://github.com/user-attachments/assets/b8d9acc4-ddf0-4842-952b-a3bd68d8a526)
