### PR TITLE
Consolidate all race predictors into one model

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Train Race Predictor Models
-        run: npm run train-race-predictor-models
+        run: npm run train-race-predictor-model
       - name: Build
         run: npm run build
       - name: Setup Pages

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "train-race-predictor-models": "node ./scripts/train-race-predictor-models.js",
+    "train-race-predictor-model": "node ./scripts/train-race-predictor-model.js",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
   },

--- a/scripts/train-race-predictor-model.js
+++ b/scripts/train-race-predictor-model.js
@@ -28,14 +28,6 @@ function parseValue(value) {
     }
 }
 
-const columns = [
-    "1mile",
-    "5km",
-    "10km",
-    "half-marathon",
-    "marathon"
-];
-
 function predictRegression(model, x) {
     let value = 0.0;
 
@@ -54,23 +46,28 @@ const lines = await Promise.all(files.map(async file => {
     return lines;
 }));
 const predictions = lines.flatMap(lines => lines.map(line => line.split(",").map(value => parseValue(value.trim()))));
-const X_train = predictions.map(row => row.slice(0, 4));
+const X_train = predictions.flatMap(row => {
+    return [
+        [...row.slice(0, 4), 1609],
+        [...row.slice(0, 4), 5000],
+        [...row.slice(0, 4), 10000],
+        [...row.slice(0, 4), 21097.5],
+        [...row.slice(0, 4), 42195],
+    ];
+});
+const y_train = predictions.flatMap(row => row.slice(4));
+const model = new XGBoost({
+    learningRate: 0.01,
+    maxDepth: 5,
+    minChildWeight: 1,
+    numRounds: 500,
+});
 
-for (let i = 4; i < predictions[0].length; i++) {
-    const y_train = predictions.map(row => row[i]);
-    const model = new XGBoost({
-        learningRate: 0.01,
-        maxDepth: 3,
-        minChildWeight: 1,
-        numRounds: 500
-    });
+model.fit(X_train, y_train);
+console.log(`Feature Importance`, model.getFeatureImportance());
+console.log(`Prediction`, predictRegression(model, [240, 58, 38, 1, 5000]));
 
-    model.fit(X_train, y_train);
-    console.log(`${columns[i-4]}: Feature Importance`, model.getFeatureImportance());
-    console.log(`${columns[i-4]}: Prediction`, predictRegression(model, [240, 58, 38, 1]));
-
-    await fs.promises.writeFile(
-        `public/models/race-predictor-${columns[i-4]}.json`,
-        JSON.stringify(model.toJSON())
-    );
-}
+await fs.promises.writeFile(
+    `public/models/race-predictor.json`,
+    JSON.stringify(model.toJSON())
+);

--- a/src/features/race-predictor/RacePredictor.tsx
+++ b/src/features/race-predictor/RacePredictor.tsx
@@ -6,11 +6,11 @@ const DEFAULT_LT2_PACE = "04:08";
 const DEFAULT_AGE = 38;
 const DEFAULT_GENDER = "male";
 const DISTANCES = [
-  { label: '1 mile', value: '1mile' },
-  { label: '5 kilometers', value: '5km' },
-  { label: '10 kilometers', value: '10km' },
-  { label: 'Half Marathon', value: 'half-marathon' },
-  { label: 'Marathon', value: 'marathon' },
+  { label: '1 mile', value: 1609 },
+  { label: '5 kilometers', value: 5000 },
+  { label: '10 kilometers', value: 10000 },
+  { label: 'Half Marathon', value: 21097.5 },
+  { label: 'Marathon', value: 42195 },
 ];
 const NUMBER_FORMAT = new Intl.NumberFormat(undefined, {
   minimumIntegerDigits: 2,
@@ -42,12 +42,13 @@ function parsePace(hhmm: number) {
   return 60 * hours + minutes;
 }
 
-function predictPace(model: XGBoost, racer: Racer) {
+function predictPace(model: XGBoost, racer: Racer, distance: number) {
   const x = [
     racer.lt2pace,
     racer.vo2max,
     racer.age,
     racer.gender === "male" ? 1 : 0,
+    distance,
   ];
   let regressionValue = 0.0;
 
@@ -61,16 +62,17 @@ function predictPace(model: XGBoost, racer: Racer) {
 interface RacePredictionProps {
   model: XGBoost;
   racer: Racer;
+  distance: number;
 }
 
-function RacePrediction({ model, racer }: RacePredictionProps) {
-  const prediction = useMemo(() => predictPace(model, racer), [model, racer]);
+function RacePrediction({ model, racer, distance }: RacePredictionProps) {
+  const prediction = useMemo(() => predictPace(model, racer, distance), [model, racer, distance]);
 
   return <>{formatSeconds(prediction)}</>;
 }
 
 function RacePredictor() {
-  const [models, setModels] = useState<XGBoost[] | null>(null);
+  const [racePredictorModel, setRacePredictorModel] = useState<XGBoost | null>(null);
   const [racers, setRacers] = useState<Racer[]>([]);
   const addRacer = (e: FormEvent<HTMLFormElement>) => {
     const form = e.target as HTMLFormElement;
@@ -90,16 +92,11 @@ function RacePredictor() {
 
   useEffect(() => {
     const fetchData = async() => {
-      setModels(
-        await Promise.all(
-          DISTANCES.map(async (distance) => {
-            const response = await fetch(`models/race-predictor-${distance.value}.json`);
-            const modelData = await response.json();
+      const response = await fetch(`models/race-predictor.json`);
+      const modelData = await response.json();
+      const model = XGBoost.fromJSON(modelData);
 
-            return XGBoost.fromJSON(modelData);
-          })
-        )
-      );
+      setRacePredictorModel(model);
     };
 
     fetchData();
@@ -147,13 +144,13 @@ function RacePredictor() {
           <td>{racer.gender === "male" ? "Male" : "Female"}</td>
           <td>{racer.vo2max}</td>
           <td>{formatSeconds(racer.lt2pace)}</td>
-          {DISTANCES.map((distance, index) => {
-            if (!models) {
+          {DISTANCES.map(distance => {
+            if (!racePredictorModel) {
               return <td key={distance.value} colSpan={2}>...</td>;
             }
 
             return <td key={distance.value}>
-              <RacePrediction model={models[index]} racer={racer} />
+              <RacePrediction model={racePredictorModel} racer={racer} distance={distance.value} />
             </td>;
           })}
         </tr>)}


### PR DESCRIPTION
Merge all race predictors into a single boosted gradient tree by adding the distance as an input parameter. This reduce load time (since we can load a single, even if slightly larger model) and improve the ability of the model to generalize.